### PR TITLE
call le_poke() after le_write_string(...)

### DIFF
--- a/lelib/lecore.m
+++ b/lelib/lecore.m
@@ -229,6 +229,7 @@ void le_write_string(NSString* string)
         NSUInteger totalLength = token_length + 1 + usedLength;
         buffer[totalLength++] = '\n';
         write_buffer((size_t)totalLength);
+        le_poke();
     });
 }
 


### PR DESCRIPTION
this matches `le_log(...)`s behavior.

without this, if you're using the C api and passing in a `NSString` object, logs aren't sent automatically and you're left scratching your head as to why.