### PR TITLE
Update LEBackgroundThread.m with the right security level

### DIFF
--- a/lelib/LEBackgroundThread.m
+++ b/lelib/LEBackgroundThread.m
@@ -57,7 +57,7 @@
     self.outputSocketStream = (__bridge_transfer NSOutputStream *)writeStream;
     
 #if LOGENTRIES_USE_TLS
-    [self.outputSocketStream setProperty:(__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL
+    [self.outputSocketStream setProperty:(__bridge id)kCFStreamSocketSecurityLevelTLSv1
                                   forKey:(__bridge id)kCFStreamPropertySocketSecurityLevel];
 #endif
     


### PR DESCRIPTION
Use 'TLSv1' security level instead of 'NegotiatedSSL' to avoid outputSocketStream getting stucked in opening state and to make it actually possible to send logs. See [related issue](https://github.com/LogentriesCommunity/le_ios/issues/37).